### PR TITLE
Fix single-select filter handling for empty values

### DIFF
--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -11,7 +11,7 @@ export const hasMultiSelectValues = (values: string[] | undefined): boolean => {
  * Helper to check if a single-select filter has an active selection
  */
 export const hasSingleSelectValue = (value: string | null | undefined): boolean => {
-  return value != null;
+  return value != null && value !== '';
 };
 
 /**
@@ -55,11 +55,11 @@ export const matchesMultiSelectFilter = <T>(
  * Helper to check if a value matches the single-select filter
  */
 export const matchesSingleSelectFilter = <T>(
-  items: T[], 
-  filterValue: string | null, 
+  items: T[],
+  filterValue: string | null,
   getValue: (item: T) => string
 ): T[] => {
-  if (filterValue == null) return items;
+  if (filterValue == null || filterValue === '') return items;
   return items.filter(item => getValue(item) === filterValue);
 };
 


### PR DESCRIPTION
## Summary
- treat empty strings as unset in `hasSingleSelectValue`
- avoid filtering when single-select filter value is empty

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894eafbe5a08324af845c8891864f30